### PR TITLE
Releasing snapshot

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,9 +23,9 @@ jobs:
           restore-keys: ${{ runner.os }}-m2
       - name: Version
         run: |
-          mvn versions:set -DnewVersion=${GITHUB_REF/refs\/tags\/v/} -DgenerateBackupPoms=false
+          mvn versions:set -DnewVersion=${GITHUB_REF/refs\/tags\/v/}-SNAPSHOT -DgenerateBackupPoms=false
           cd qudini-reactive-example
-          mvn versions:set -DnewVersion=${GITHUB_REF/refs\/tags\/v/} -DgenerateBackupPoms=false
+          mvn versions:set -DnewVersion=${GITHUB_REF/refs\/tags\/v/}-SNAPSHOT -DgenerateBackupPoms=false
           cd ..
       - name: Release
         run: |


### PR DESCRIPTION
According to https://stackoverflow.com/a/20056439/1225328:

>You're trying to release an artifact that's not a snapshot. That means your artifact's version number is something like 3.0.3. That version number implies its already been released. You can't release a release. There would be no changes in between and therefore no point.

> You're only supposed to release SNAPSHOT versions. That means your version number would be like 3.0.3-SNAPSHOT.