### PR TITLE
Error trackers

### DIFF
--- a/qudini-reactive-example/pom.xml
+++ b/qudini-reactive-example/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.2.5.RELEASE</version>
+        <version>2.3.1.RELEASE</version>
         <relativePath/>
     </parent>
 

--- a/qudini-reactive-logging/README.md
+++ b/qudini-reactive-logging/README.md
@@ -119,13 +119,15 @@ You can provide your own implementation by registering a component implementing 
 
 ### Additional logging context properties
 
-By default, the build version will be added in the logging context, under the key `"build_version"`.
+By default, the logging context will hold:
 
-This value will be read from `com.qudini.reactive.utils.build.BuildInfoService`, [see the defaults and how to override them](https://github.com/qudini/qudini-reactive/tree/master/qudini-reactive-utils).
+- the environment, mapped to the key `"environment"`,
+- the build name, mapped to the key `"build_name"`,
+- the build version, mapped to the key `"build_version"`.
 
-No additional logging context will be extracted from the incoming request.
+Those values will be read from `com.qudini.reactive.utils.metadata.MetadataService` ([see the defaults and how to override them](https://github.com/qudini/qudini-reactive/tree/master/qudini-reactive-utils)).
 
-You can override these defaults by implementing `com.qudini.reactive.logging.web.LoggingContextExtractor`, for example if you need more domain-specific properties to be available in the MDC.
+You can override these defaults registering a component implementing `com.qudini.reactive.logging.web.LoggingContextExtractor`, for example if you need more domain-specific properties to be available in the MDC (you'll have access to the incoming HTTP request).
 
 ### Reactive context creation
 

--- a/qudini-reactive-logging/README.md
+++ b/qudini-reactive-logging/README.md
@@ -121,15 +121,11 @@ You can provide your own implementation by registering a component implementing 
 
 ### Additional logging context properties
 
-By default, the logging context will hold:
+By default, the logging context will hold the build version, mapped to the key `"build_version"`.
 
-- the environment, mapped to the key `"environment"`,
-- the build name, mapped to the key `"build_name"`,
-- the build version, mapped to the key `"build_version"`.
+This value will be read from `com.qudini.reactive.utils.metadata.MetadataService` ([see the defaults and how to override them](https://github.com/qudini/qudini-reactive/tree/master/qudini-reactive-utils)).
 
-Those values will be read from `com.qudini.reactive.utils.metadata.MetadataService` ([see the defaults and how to override them](https://github.com/qudini/qudini-reactive/tree/master/qudini-reactive-utils)).
-
-You can override these defaults registering a component implementing `com.qudini.reactive.logging.web.LoggingContextExtractor`, for example if you need more domain-specific properties to be available in the MDC (you'll have access to the incoming HTTP request).
+You can override these defaults by registering a component implementing `com.qudini.reactive.logging.web.LoggingContextExtractor`, for example if you need more domain-specific properties to be available in the MDC (you'll have access to the incoming HTTP request).
 
 ### Third-party error trackers
 
@@ -150,13 +146,9 @@ The logging context will be passed through as `params`, as well as:
 
 If `io.sentry.Sentry` is found in the classpath, errors will be pushed to [Sentry](https://sentry.io/) via `Sentry.captureEvent(event)`.
 
+Sentry's `environment` and `release` will be populated thanks to `com.qudini.reactive.utils.metadata.MetadataService` ([see the defaults and how to override them](https://github.com/qudini/qudini-reactive/tree/master/qudini-reactive-utils)). 
+
 The log event will be used to populate the Sentry event.
-
-If the logging context has a key `"build_version"`, its value will be used for the Sentry `release`.
-
-If the logging context has a key `"environment"`, its value will be used for the Sentry `environment`.
-
-As explained in [Additional logging context properties](#additional-logging-context-properties), those two keys will already be available in the logging context by default.
 
 ### Reactive context creation
 

--- a/qudini-reactive-logging/README.md
+++ b/qudini-reactive-logging/README.md
@@ -121,7 +121,7 @@ You can provide your own implementation by registering a component implementing 
 
 By default, the build version will be added in the logging context, under the key `"build_version"`.
 
-This value will be read from `com.qudini.reactive.utils.build.BuildInfoService`, [see the defaults and how to override them if needed](https://github.com/qudini/qudini-reactive/tree/master/qudini-reactive-utils).
+This value will be read from `com.qudini.reactive.utils.build.BuildInfoService`, [see the defaults and how to override them](https://github.com/qudini/qudini-reactive/tree/master/qudini-reactive-utils).
 
 No additional logging context will be extracted from the incoming request.
 

--- a/qudini-reactive-logging/README.md
+++ b/qudini-reactive-logging/README.md
@@ -119,7 +119,13 @@ You can provide your own implementation by registering a component implementing 
 
 ### Additional logging context properties
 
-By default, no additional logging context will be extracted from the incoming request, but you can implement `com.qudini.reactive.logging.web.LoggingContextExtractor` if you need more domain-specific properties to be available in the MDC.
+By default, the build version will be added in the logging context, under the key `"build_version"`.
+
+This value will be read from `com.qudini.reactive.utils.build.BuildInfoService`, [see the defaults and how to override them if needed](https://github.com/qudini/qudini-reactive/tree/master/qudini-reactive-utils).
+
+No additional logging context will be extracted from the incoming request.
+
+You can override these defaults by implementing `com.qudini.reactive.logging.web.LoggingContextExtractor`, for example if you need more domain-specific properties to be available in the MDC.
 
 ### Reactive context creation
 

--- a/qudini-reactive-logging/README.md
+++ b/qudini-reactive-logging/README.md
@@ -25,14 +25,30 @@ Fixes logging in a reactive stream, by handling the MDC inside the reactive cont
 
 You can leave the defaults, everything will just work out of the box. You can also reconfigure it to match your requirements, as explained in the following sections.
 
-### JSON structured logging
+### Log4j 2
 
 By default, a custom Log4j 2 configuration will be used, with:
 
 - an asynchronous root logger,
 - the log level set from the environment variable `LOG_LEVEL`, defaulting to `INFO`,
-- a console appender targeting `SYSTEM_OUT`,
-- a custom JSON layout.
+- a console appender targeting `SYSTEM_OUT`, using a custom JSON layout,
+- a custom appender that pushes errors to third-party error trackers.
+
+If you want to use the default configuration Spring provides, update your `application.yml` with the following (might be useful for development environment):
+
+```yaml
+logging:
+  config: default
+```
+
+If you want to use another custom configuration of yours, use:
+
+```yaml
+logging:
+  config: classpath:your-log4j2-config.xml
+```
+
+### JSON structured logging
 
 The JSON layout will produce logs according to the following format:
 
@@ -48,20 +64,6 @@ The JSON layout will produce logs according to the following format:
   "<mdc key 2>": "<mdc value 2>",
   "...": "..."
 }
-```
-
-If you want to use the default configuration Spring provides, update your `application.yml` with the following (might be useful for development environment):
-
-```yaml
-logging:
-  config: default
-```
-
-If you want to use another custom configuration of yours, use:
-
-```yaml
-logging:
-  config: classpath:your-log4j2-config.xml
 ```
 
 ### Correlation id
@@ -128,6 +130,33 @@ By default, the logging context will hold:
 Those values will be read from `com.qudini.reactive.utils.metadata.MetadataService` ([see the defaults and how to override them](https://github.com/qudini/qudini-reactive/tree/master/qudini-reactive-utils)).
 
 You can override these defaults registering a component implementing `com.qudini.reactive.logging.web.LoggingContextExtractor`, for example if you need more domain-specific properties to be available in the MDC (you'll have access to the incoming HTTP request).
+
+### Third-party error trackers
+
+If the JDK of a supported third-party error tracker is found in the classpath, logs at level `ERROR` or above will be pushed to them.
+
+#### NewRelic
+
+If `com.newrelic.api.agent.NewRelic` is found in the classpath, errors will be pushed to [NewRelic](https://newrelic.com/) via `NewRelic.noticeError(errorOrMessage, params)`.
+
+The logging context will be passed through as `params`, as well as:
+
+- the timestamp,
+- the log level,
+- the logger,
+- the logged message.
+
+#### Sentry
+
+If `io.sentry.Sentry` is found in the classpath, errors will be pushed to [Sentry](https://sentry.io/) via `Sentry.captureEvent(event)`.
+
+The log event will be used to populate the Sentry event.
+
+If the logging context has a key `"build_version"`, its value will be used for the Sentry `release`.
+
+If the logging context has a key `"environment"`, its value will be used for the Sentry `environment`.
+
+As explained in [Additional logging context properties](#additional-logging-context-properties), those two keys will already be available in the logging context by default.
 
 ### Reactive context creation
 

--- a/qudini-reactive-logging/pom.xml
+++ b/qudini-reactive-logging/pom.xml
@@ -26,6 +26,18 @@
             <version>3.4.2</version>
         </dependency>
         <dependency>
+            <groupId>com.newrelic.agent.java</groupId>
+            <artifactId>newrelic-api</artifactId>
+            <version>5.6.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.sentry</groupId>
+            <artifactId>sentry</artifactId>
+            <version>3.1.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>com.qudini</groupId>
             <artifactId>qudini-reactive-tests</artifactId>
             <version>${project.version}</version>

--- a/qudini-reactive-logging/src/main/java/com/qudini/reactive/logging/Log.java
+++ b/qudini-reactive-logging/src/main/java/com/qudini/reactive/logging/Log.java
@@ -24,9 +24,9 @@ import static java.util.Collections.unmodifiableMap;
 @RequiredArgsConstructor
 public final class Log implements ReactiveLoggingContextCreator {
 
-    private static final String LOGGING_MDC_KEY = "LOGGING_MDC";
+    public static final String LOGGING_MDC_KEY = "LOGGING_MDC";
 
-    private static final String CORRELATION_ID_KEY = "correlation_id";
+    public static final String CORRELATION_ID_KEY = "correlation_id";
 
     private final CorrelationIdGenerator correlationIdGenerator;
 

--- a/qudini-reactive-logging/src/main/java/com/qudini/reactive/logging/ReactiveLoggingAutoConfiguration.java
+++ b/qudini-reactive-logging/src/main/java/com/qudini/reactive/logging/ReactiveLoggingAutoConfiguration.java
@@ -10,6 +10,7 @@ import com.qudini.reactive.logging.web.DefaultCorrelationIdForwarder;
 import com.qudini.reactive.logging.web.DefaultLoggingContextExtractor;
 import com.qudini.reactive.logging.web.LoggingContextExtractor;
 import com.qudini.reactive.logging.web.LoggingContextFilter;
+import com.qudini.reactive.utils.build.BuildInfoService;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
@@ -35,8 +36,8 @@ public class ReactiveLoggingAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    public LoggingContextExtractor loggingContextExtractor() {
-        return new DefaultLoggingContextExtractor();
+    public LoggingContextExtractor loggingContextExtractor(BuildInfoService buildInfoService) {
+        return new DefaultLoggingContextExtractor(buildInfoService);
     }
 
     @Bean

--- a/qudini-reactive-logging/src/main/java/com/qudini/reactive/logging/ReactiveLoggingAutoConfiguration.java
+++ b/qudini-reactive-logging/src/main/java/com/qudini/reactive/logging/ReactiveLoggingAutoConfiguration.java
@@ -10,7 +10,7 @@ import com.qudini.reactive.logging.web.DefaultCorrelationIdForwarder;
 import com.qudini.reactive.logging.web.DefaultLoggingContextExtractor;
 import com.qudini.reactive.logging.web.LoggingContextExtractor;
 import com.qudini.reactive.logging.web.LoggingContextFilter;
-import com.qudini.reactive.utils.build.BuildInfoService;
+import com.qudini.reactive.utils.metadata.MetadataService;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
@@ -36,8 +36,8 @@ public class ReactiveLoggingAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    public LoggingContextExtractor loggingContextExtractor(BuildInfoService buildInfoService) {
-        return new DefaultLoggingContextExtractor(buildInfoService);
+    public LoggingContextExtractor loggingContextExtractor(MetadataService metadataService) {
+        return new DefaultLoggingContextExtractor(metadataService);
     }
 
     @Bean

--- a/qudini-reactive-logging/src/main/java/com/qudini/reactive/logging/ReactiveLoggingAutoConfiguration.java
+++ b/qudini-reactive-logging/src/main/java/com/qudini/reactive/logging/ReactiveLoggingAutoConfiguration.java
@@ -5,6 +5,7 @@ import com.qudini.reactive.logging.aop.JoinPointSerialiser;
 import com.qudini.reactive.logging.aop.LoggedAspect;
 import com.qudini.reactive.logging.correlation.CorrelationIdGenerator;
 import com.qudini.reactive.logging.correlation.DefaultCorrelationIdGenerator;
+import com.qudini.reactive.logging.log4j2.Trackers;
 import com.qudini.reactive.logging.web.CorrelationIdForwarder;
 import com.qudini.reactive.logging.web.DefaultCorrelationIdForwarder;
 import com.qudini.reactive.logging.web.DefaultLoggingContextExtractor;
@@ -13,8 +14,10 @@ import com.qudini.reactive.logging.web.LoggingContextFilter;
 import com.qudini.reactive.utils.metadata.MetadataService;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.event.EventListener;
 import org.springframework.web.server.WebFilter;
 
 @Configuration
@@ -66,6 +69,14 @@ public class ReactiveLoggingAutoConfiguration {
     @Bean
     public LoggedAspect loggedAspect(JoinPointSerialiser joinPointSerialiser) {
         return new LoggedAspect(joinPointSerialiser);
+    }
+
+    @EventListener(ApplicationReadyEvent.class)
+    public void start(ApplicationReadyEvent applicationReadyEvent) {
+        var metadataService = applicationReadyEvent
+                .getApplicationContext()
+                .getBean(MetadataService.class);
+        Trackers.init(metadataService);
     }
 
 }

--- a/qudini-reactive-logging/src/main/java/com/qudini/reactive/logging/log4j2/ErrorTrackerAppender.java
+++ b/qudini-reactive-logging/src/main/java/com/qudini/reactive/logging/log4j2/ErrorTrackerAppender.java
@@ -35,8 +35,8 @@ public final class ErrorTrackerAppender extends AbstractAppender {
 
     @Override
     public void append(LogEvent logEvent) {
-        var event = new QudiniLogEvent(logEvent);
-        if (event.getLevel().isMoreSpecificThan(ERROR) && !trackers.isEmpty()) {
+        if (logEvent.getLevel().isMoreSpecificThan(ERROR) && !trackers.isEmpty()) {
+            var event = QudiniLogEvent.of(logEvent);
             trackers.forEach(tracker -> tracker.track(event));
         }
     }

--- a/qudini-reactive-logging/src/main/java/com/qudini/reactive/logging/log4j2/ErrorTrackerAppender.java
+++ b/qudini-reactive-logging/src/main/java/com/qudini/reactive/logging/log4j2/ErrorTrackerAppender.java
@@ -34,9 +34,10 @@ public final class ErrorTrackerAppender extends AbstractAppender {
     }
 
     @Override
-    public void append(LogEvent event) {
-        if (event.getLevel().isMoreSpecificThan(ERROR)) {
-            trackers.forEach(appender -> appender.track(event));
+    public void append(LogEvent logEvent) {
+        var event = new QudiniLogEvent(logEvent);
+        if (event.getLevel().isMoreSpecificThan(ERROR) && !trackers.isEmpty()) {
+            trackers.forEach(tracker -> tracker.track(event));
         }
     }
 

--- a/qudini-reactive-logging/src/main/java/com/qudini/reactive/logging/log4j2/ErrorTrackerAppender.java
+++ b/qudini-reactive-logging/src/main/java/com/qudini/reactive/logging/log4j2/ErrorTrackerAppender.java
@@ -25,13 +25,7 @@ public final class ErrorTrackerAppender extends AbstractAppender {
 
     private ErrorTrackerAppender(String name, Filter filter, Layout<? extends Serializable> layout, boolean ignoreExceptions, Property[] properties) {
         super(name, filter, layout, ignoreExceptions, properties);
-        this.trackers = Stream
-                .of(
-                        loadTracker("NewRelic", "com.newrelic.api.agent.NewRelic"),
-                        loadTracker("Sentry", "io.sentry.Sentry")
-                )
-                .flatMap(Optional::stream)
-                .collect(toUnmodifiableSet());
+        this.trackers = loadTrackers();
     }
 
     @PluginFactory
@@ -46,7 +40,17 @@ public final class ErrorTrackerAppender extends AbstractAppender {
         }
     }
 
-    private Optional<Tracker> loadTracker(String trackerName, String conditionalClassName) {
+    private static Set<Tracker> loadTrackers() {
+        return Stream
+                .of(
+                        loadTracker("NewRelic", "com.newrelic.api.agent.NewRelic"),
+                        loadTracker("Sentry", "io.sentry.Sentry")
+                )
+                .flatMap(Optional::stream)
+                .collect(toUnmodifiableSet());
+    }
+
+    private static Optional<Tracker> loadTracker(String trackerName, String conditionalClassName) {
         if (classExists(conditionalClassName)) {
             var trackerClassName = "com.qudini.reactive.logging.log4j2.trackers." + trackerName + "Tracker";
             try {
@@ -60,7 +64,7 @@ public final class ErrorTrackerAppender extends AbstractAppender {
         }
     }
 
-    private boolean classExists(String name) {
+    private static boolean classExists(String name) {
         try {
             Class.forName(name);
             return true;

--- a/qudini-reactive-logging/src/main/java/com/qudini/reactive/logging/log4j2/ErrorTrackerAppender.java
+++ b/qudini-reactive-logging/src/main/java/com/qudini/reactive/logging/log4j2/ErrorTrackerAppender.java
@@ -1,0 +1,72 @@
+package com.qudini.reactive.logging.log4j2;
+
+import org.apache.logging.log4j.core.Filter;
+import org.apache.logging.log4j.core.Layout;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.Property;
+import org.apache.logging.log4j.core.config.plugins.Plugin;
+import org.apache.logging.log4j.core.config.plugins.PluginFactory;
+
+import java.io.Serializable;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.toUnmodifiableSet;
+import static org.apache.logging.log4j.Level.ERROR;
+import static org.apache.logging.log4j.core.Appender.ELEMENT_TYPE;
+import static org.apache.logging.log4j.core.Core.CATEGORY_NAME;
+
+@Plugin(name = "ErrorTrackerAppender", category = CATEGORY_NAME, elementType = ELEMENT_TYPE)
+public final class ErrorTrackerAppender extends AbstractAppender {
+
+    private final Set<Tracker> trackers;
+
+    private ErrorTrackerAppender(String name, Filter filter, Layout<? extends Serializable> layout, boolean ignoreExceptions, Property[] properties) {
+        super(name, filter, layout, ignoreExceptions, properties);
+        this.trackers = Stream
+                .of(
+                        loadTracker("NewRelic", "com.newrelic.api.agent.NewRelic"),
+                        loadTracker("Sentry", "io.sentry.Sentry")
+                )
+                .flatMap(Optional::stream)
+                .collect(toUnmodifiableSet());
+    }
+
+    @PluginFactory
+    public static ErrorTrackerAppender newInstance(String name, Filter filter, Layout<? extends Serializable> layout, boolean ignoreExceptions, Property[] properties) {
+        return new ErrorTrackerAppender(name, filter, layout, ignoreExceptions, properties);
+    }
+
+    @Override
+    public void append(LogEvent event) {
+        if (event.getLevel().isMoreSpecificThan(ERROR)) {
+            trackers.forEach(appender -> appender.track(event));
+        }
+    }
+
+    private Optional<Tracker> loadTracker(String trackerName, String conditionalClassName) {
+        if (classExists(conditionalClassName)) {
+            var trackerClassName = "com.qudini.reactive.logging.log4j2.trackers." + trackerName + "Tracker";
+            try {
+                var tracker = (Tracker) Class.forName(trackerClassName).getDeclaredConstructor().newInstance();
+                return Optional.of(tracker);
+            } catch (Exception e) {
+                throw new IllegalStateException("Unable to load tracker " + trackerClassName, e);
+            }
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    private boolean classExists(String name) {
+        try {
+            Class.forName(name);
+            return true;
+        } catch (ClassNotFoundException e) {
+            return false;
+        }
+    }
+
+}

--- a/qudini-reactive-logging/src/main/java/com/qudini/reactive/logging/log4j2/QudiniJsonLayout.java
+++ b/qudini-reactive-logging/src/main/java/com/qudini/reactive/logging/log4j2/QudiniJsonLayout.java
@@ -47,9 +47,12 @@ public final class QudiniJsonLayout extends AbstractStringLayout {
         return new QudiniJsonLayout();
     }
 
+    public String toSerializable(LogEvent event) {
+        return toSerializable(QudiniLogEvent.of(event));
+    }
+
     @SneakyThrows
-    public String toSerializable(LogEvent logEvent) {
-        var event = QudiniLogEvent.of(logEvent);
+    private String toSerializable(QudiniLogEvent event) {
         try (
                 var writer = new StringWriter();
                 var generator = JSON_FACTORY.createGenerator(writer)

--- a/qudini-reactive-logging/src/main/java/com/qudini/reactive/logging/log4j2/QudiniJsonLayout.java
+++ b/qudini-reactive-logging/src/main/java/com/qudini/reactive/logging/log4j2/QudiniJsonLayout.java
@@ -11,10 +11,8 @@ import org.apache.logging.log4j.core.layout.AbstractStringLayout;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.Set;
-import java.util.StringJoiner;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static java.time.Instant.ofEpochMilli;
 import static java.time.format.DateTimeFormatter.ISO_INSTANT;
 import static org.apache.logging.log4j.core.Layout.ELEMENT_TYPE;
 import static org.apache.logging.log4j.core.config.Node.CATEGORY;
@@ -51,52 +49,25 @@ public final class QudiniJsonLayout extends AbstractStringLayout {
 
     @SneakyThrows
     public String toSerializable(LogEvent logEvent) {
-
-        var timestamp = logEvent.getTimeMillis();
-        var thread = logEvent.getThreadName();
-        var loggerName = logEvent.getLoggerName();
-        var logLevel = logEvent.getLevel().toString();
-
-        var message = new StringJoiner(" / ");
-        var logMessage = logEvent.getMessage().getFormattedMessage();
-        if (null != logMessage) {
-            message.add(logMessage);
-        }
-
-        final String stacktrace;
-        var thrown = logEvent.getThrown();
-        if (null != thrown) {
-            message.add(thrown.getClass().getName());
-            var exceptionMessage = thrown.getMessage();
-            if (null != exceptionMessage) {
-                message.add(exceptionMessage);
-            }
-            stacktrace = readStackTrace(thrown);
-        } else {
-            stacktrace = null;
-        }
-
-        var mdc = logEvent.getContextData();
-
+        var event = new QudiniLogEvent(logEvent);
         try (
                 var writer = new StringWriter();
                 var generator = JSON_FACTORY.createGenerator(writer)
         ) {
             generator.writeStartObject();
-            mdc.forEach((key, value) -> writeMdcEntry(generator, key, value));
-            generator.writeStringField(TIMESTAMP_KEY, ISO_INSTANT.format(ofEpochMilli(timestamp)));
-            generator.writeStringField(LEVEL_KEY, logLevel);
-            generator.writeStringField(THREAD_KEY, thread);
-            generator.writeStringField(LOGGER_KEY, loggerName);
-            generator.writeStringField(MESSAGE_KEY, message.toString());
-            if (null != stacktrace) {
-                generator.writeStringField(STACKTRACE_KEY, stacktrace);
+            event.getContext().forEach((key, value) -> writeMdcEntry(generator, key, value));
+            generator.writeStringField(TIMESTAMP_KEY, ISO_INSTANT.format(event.getTimestamp()));
+            generator.writeStringField(LEVEL_KEY, event.getLevel().toString());
+            generator.writeStringField(THREAD_KEY, event.getThread());
+            generator.writeStringField(LOGGER_KEY, event.getLogger());
+            generator.writeStringField(MESSAGE_KEY, event.getMessage());
+            if (null != event.getError()) {
+                generator.writeStringField(STACKTRACE_KEY, readStackTrace(event.getError()));
             }
             generator.writeEndObject();
             generator.flush();
             return writer + "\n";
         }
-
     }
 
     @SneakyThrows

--- a/qudini-reactive-logging/src/main/java/com/qudini/reactive/logging/log4j2/QudiniJsonLayout.java
+++ b/qudini-reactive-logging/src/main/java/com/qudini/reactive/logging/log4j2/QudiniJsonLayout.java
@@ -60,7 +60,7 @@ public final class QudiniJsonLayout extends AbstractStringLayout {
             generator.writeStartObject();
             event.getContext().forEach((key, value) -> writeMdcEntry(generator, key, value));
             writeEntry(generator, TIMESTAMP_KEY, ISO_INSTANT.format(event.getTimestamp()));
-            writeEntry(generator, LEVEL_KEY, event.getLevel().toString());
+            writeEntry(generator, LEVEL_KEY, event.getLevel().name());
             writeEntry(generator, MESSAGE_KEY, event.getMessage());
             event.getThread().ifPresent(thread -> writeEntry(generator, THREAD_KEY, thread));
             event.getLogger().ifPresent(logger -> writeEntry(generator, LOGGER_KEY, logger));

--- a/qudini-reactive-logging/src/main/java/com/qudini/reactive/logging/log4j2/QudiniLogEvent.java
+++ b/qudini-reactive-logging/src/main/java/com/qudini/reactive/logging/log4j2/QudiniLogEvent.java
@@ -2,11 +2,11 @@ package com.qudini.reactive.logging.log4j2;
 
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.LogEvent;
-import org.apache.logging.log4j.core.impl.ContextDataFactory;
 import org.apache.logging.log4j.message.Message;
 import org.apache.logging.log4j.util.ReadOnlyStringMap;
 
 import java.time.Instant;
+import java.util.Map;
 import java.util.Optional;
 import java.util.StringJoiner;
 
@@ -19,7 +19,7 @@ public final class QudiniLogEvent {
     private final Level level;
     private final Optional<Throwable> error;
     private final String message;
-    private final ReadOnlyStringMap context;
+    private final Map<String, String> context;
 
     private QudiniLogEvent(LogEvent event) {
 
@@ -29,7 +29,7 @@ public final class QudiniLogEvent {
         this.logger = Optional.ofNullable(event.getLoggerName());
         this.level = event.getLevel();
         this.error = Optional.ofNullable(event.getThrown());
-        this.context = Optional.ofNullable(event.getContextData()).orElseGet(ContextDataFactory::emptyFrozenContextData);
+        this.context = Optional.ofNullable(event.getContextData()).map(ReadOnlyStringMap::toMap).map(Map::copyOf).orElseGet(Map::of);
 
         var message = new StringJoiner(" / ");
         Optional.ofNullable(event.getMessage()).map(Message::getFormattedMessage).ifPresent(message::add);
@@ -75,7 +75,7 @@ public final class QudiniLogEvent {
         return message;
     }
 
-    public ReadOnlyStringMap getContext() {
+    public Map<String, String> getContext() {
         return context;
     }
 

--- a/qudini-reactive-logging/src/main/java/com/qudini/reactive/logging/log4j2/QudiniLogEvent.java
+++ b/qudini-reactive-logging/src/main/java/com/qudini/reactive/logging/log4j2/QudiniLogEvent.java
@@ -1,0 +1,75 @@
+package com.qudini.reactive.logging.log4j2;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.util.ReadOnlyStringMap;
+
+import java.time.Instant;
+import java.util.StringJoiner;
+
+public final class QudiniLogEvent {
+
+    private final Instant timestamp;
+    private final String thread;
+    private final String logger;
+    private final Level level;
+    private final Throwable error;
+    private final String message;
+    private final ReadOnlyStringMap context;
+
+    QudiniLogEvent(LogEvent event) {
+
+        this.timestamp = Instant.ofEpochMilli(event.getTimeMillis());
+        this.thread = event.getThreadName();
+        this.logger = event.getLoggerName();
+        this.level = event.getLevel();
+        this.error = event.getThrown();
+        this.context = event.getContextData();
+
+        var message = new StringJoiner(" / ");
+        var logMessage = event.getMessage().getFormattedMessage();
+        if (null != logMessage) {
+            message.add(logMessage);
+        }
+
+        if (null != error) {
+            message.add(error.getClass().getName());
+            var exceptionMessage = error.getMessage();
+            if (null != exceptionMessage) {
+                message.add(exceptionMessage);
+            }
+        }
+
+        this.message = message.toString();
+
+    }
+
+    public Instant getTimestamp() {
+        return timestamp;
+    }
+
+    public String getThread() {
+        return thread;
+    }
+
+    public String getLogger() {
+        return logger;
+    }
+
+    public Level getLevel() {
+        return level;
+    }
+
+    public Throwable getError() {
+        return error;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public ReadOnlyStringMap getContext() {
+        return context;
+    }
+
+}

--- a/qudini-reactive-logging/src/main/java/com/qudini/reactive/logging/log4j2/QudiniLogEvent.java
+++ b/qudini-reactive-logging/src/main/java/com/qudini/reactive/logging/log4j2/QudiniLogEvent.java
@@ -2,6 +2,7 @@ package com.qudini.reactive.logging.log4j2;
 
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.impl.ContextDataFactory;
 import org.apache.logging.log4j.message.Message;
 import org.apache.logging.log4j.util.ReadOnlyStringMap;
 
@@ -28,7 +29,7 @@ public final class QudiniLogEvent {
         this.logger = Optional.ofNullable(event.getLoggerName());
         this.level = event.getLevel();
         this.error = Optional.ofNullable(event.getThrown());
-        this.context = event.getContextData();
+        this.context = Optional.ofNullable(event.getContextData()).orElseGet(ContextDataFactory::emptyFrozenContextData);
 
         var message = new StringJoiner(" / ");
         Optional.ofNullable(event.getMessage()).map(Message::getFormattedMessage).ifPresent(message::add);

--- a/qudini-reactive-logging/src/main/java/com/qudini/reactive/logging/log4j2/QudiniLogEvent.java
+++ b/qudini-reactive-logging/src/main/java/com/qudini/reactive/logging/log4j2/QudiniLogEvent.java
@@ -2,57 +2,63 @@ package com.qudini.reactive.logging.log4j2;
 
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.message.Message;
 import org.apache.logging.log4j.util.ReadOnlyStringMap;
 
 import java.time.Instant;
+import java.util.Optional;
 import java.util.StringJoiner;
 
 public final class QudiniLogEvent {
 
+    private final LogEvent originalEvent;
     private final Instant timestamp;
-    private final String thread;
-    private final String logger;
+    private final Optional<String> thread;
+    private final Optional<String> logger;
     private final Level level;
-    private final Throwable error;
+    private final Optional<Throwable> error;
     private final String message;
     private final ReadOnlyStringMap context;
 
-    QudiniLogEvent(LogEvent event) {
+    private QudiniLogEvent(LogEvent event) {
 
+        this.originalEvent = event;
         this.timestamp = Instant.ofEpochMilli(event.getTimeMillis());
-        this.thread = event.getThreadName();
-        this.logger = event.getLoggerName();
+        this.thread = Optional.ofNullable(event.getThreadName());
+        this.logger = Optional.ofNullable(event.getLoggerName());
         this.level = event.getLevel();
-        this.error = event.getThrown();
+        this.error = Optional.ofNullable(event.getThrown());
         this.context = event.getContextData();
 
         var message = new StringJoiner(" / ");
-        var logMessage = event.getMessage().getFormattedMessage();
-        if (null != logMessage) {
-            message.add(logMessage);
-        }
-
-        if (null != error) {
-            message.add(error.getClass().getName());
-            var exceptionMessage = error.getMessage();
-            if (null != exceptionMessage) {
-                message.add(exceptionMessage);
-            }
-        }
+        Optional.ofNullable(event.getMessage()).map(Message::getFormattedMessage).ifPresent(message::add);
+        error.ifPresent(error -> addErrorToMessage(message, error));
 
         this.message = message.toString();
 
+    }
+
+    private void addErrorToMessage(StringJoiner message, Throwable error) {
+        message.add(error.getClass().getName());
+        var exceptionMessage = error.getMessage();
+        if (null != exceptionMessage) {
+            message.add(exceptionMessage);
+        }
+    }
+
+    public LogEvent getOriginalEvent() {
+        return originalEvent;
     }
 
     public Instant getTimestamp() {
         return timestamp;
     }
 
-    public String getThread() {
+    public Optional<String> getThread() {
         return thread;
     }
 
-    public String getLogger() {
+    public Optional<String> getLogger() {
         return logger;
     }
 
@@ -60,7 +66,7 @@ public final class QudiniLogEvent {
         return level;
     }
 
-    public Throwable getError() {
+    public Optional<Throwable> getError() {
         return error;
     }
 
@@ -70,6 +76,10 @@ public final class QudiniLogEvent {
 
     public ReadOnlyStringMap getContext() {
         return context;
+    }
+
+    static QudiniLogEvent of(LogEvent event) {
+        return new QudiniLogEvent(event);
     }
 
 }

--- a/qudini-reactive-logging/src/main/java/com/qudini/reactive/logging/log4j2/Tracker.java
+++ b/qudini-reactive-logging/src/main/java/com/qudini/reactive/logging/log4j2/Tracker.java
@@ -1,7 +1,13 @@
 package com.qudini.reactive.logging.log4j2;
 
+import com.qudini.reactive.utils.metadata.MetadataService;
+
 public interface Tracker {
 
     void track(QudiniLogEvent event);
+
+    default void init(MetadataService metadataService) {
+        // no-op by default
+    }
 
 }

--- a/qudini-reactive-logging/src/main/java/com/qudini/reactive/logging/log4j2/Tracker.java
+++ b/qudini-reactive-logging/src/main/java/com/qudini/reactive/logging/log4j2/Tracker.java
@@ -1,0 +1,9 @@
+package com.qudini.reactive.logging.log4j2;
+
+import org.apache.logging.log4j.core.LogEvent;
+
+public interface Tracker {
+
+    void track(LogEvent event);
+
+}

--- a/qudini-reactive-logging/src/main/java/com/qudini/reactive/logging/log4j2/Tracker.java
+++ b/qudini-reactive-logging/src/main/java/com/qudini/reactive/logging/log4j2/Tracker.java
@@ -4,10 +4,10 @@ import com.qudini.reactive.utils.metadata.MetadataService;
 
 public interface Tracker {
 
-    void track(QudiniLogEvent event);
-
     default void init(MetadataService metadataService) {
         // no-op by default
     }
+
+    void track(QudiniLogEvent event);
 
 }

--- a/qudini-reactive-logging/src/main/java/com/qudini/reactive/logging/log4j2/Tracker.java
+++ b/qudini-reactive-logging/src/main/java/com/qudini/reactive/logging/log4j2/Tracker.java
@@ -1,9 +1,7 @@
 package com.qudini.reactive.logging.log4j2;
 
-import org.apache.logging.log4j.core.LogEvent;
-
 public interface Tracker {
 
-    void track(LogEvent event);
+    void track(QudiniLogEvent event);
 
 }

--- a/qudini-reactive-logging/src/main/java/com/qudini/reactive/logging/log4j2/Trackers.java
+++ b/qudini-reactive-logging/src/main/java/com/qudini/reactive/logging/log4j2/Trackers.java
@@ -14,31 +14,31 @@ import java.util.Set;
 import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.toUnmodifiableSet;
-import static org.apache.logging.log4j.Level.ERROR;
 import static org.apache.logging.log4j.core.Appender.ELEMENT_TYPE;
 import static org.apache.logging.log4j.core.Core.CATEGORY_NAME;
 
-@Plugin(name = "ErrorTrackerAppender", category = CATEGORY_NAME, elementType = ELEMENT_TYPE)
-public final class ErrorTrackerAppender extends AbstractAppender {
+@Plugin(name = "Trackers", category = CATEGORY_NAME, elementType = ELEMENT_TYPE)
+public final class Trackers extends AbstractAppender {
 
     private final Set<Tracker> trackers;
 
-    private ErrorTrackerAppender(String name, Filter filter, Layout<? extends Serializable> layout, boolean ignoreExceptions, Property[] properties) {
+    private Trackers(String name, Filter filter, Layout<? extends Serializable> layout, boolean ignoreExceptions, Property[] properties) {
         super(name, filter, layout, ignoreExceptions, properties);
         this.trackers = loadTrackers();
     }
 
     @PluginFactory
-    public static ErrorTrackerAppender newInstance(String name, Filter filter, Layout<? extends Serializable> layout, boolean ignoreExceptions, Property[] properties) {
-        return new ErrorTrackerAppender(name, filter, layout, ignoreExceptions, properties);
+    public static Trackers newInstance(String name, Filter filter, Layout<? extends Serializable> layout, boolean ignoreExceptions, Property[] properties) {
+        return new Trackers(name, filter, layout, ignoreExceptions, properties);
     }
 
     @Override
-    public void append(LogEvent logEvent) {
-        if (logEvent.getLevel().isMoreSpecificThan(ERROR) && !trackers.isEmpty()) {
-            var event = QudiniLogEvent.of(logEvent);
-            trackers.forEach(tracker -> tracker.track(event));
-        }
+    public void append(LogEvent event) {
+        append(QudiniLogEvent.of(event));
+    }
+
+    private void append(QudiniLogEvent event) {
+        trackers.forEach(tracker -> tracker.track(event));
     }
 
     private static Set<Tracker> loadTrackers() {

--- a/qudini-reactive-logging/src/main/java/com/qudini/reactive/logging/log4j2/Trackers.java
+++ b/qudini-reactive-logging/src/main/java/com/qudini/reactive/logging/log4j2/Trackers.java
@@ -1,14 +1,14 @@
 package com.qudini.reactive.logging.log4j2;
 
 import org.apache.logging.log4j.core.Filter;
-import org.apache.logging.log4j.core.Layout;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.appender.AbstractAppender;
 import org.apache.logging.log4j.core.config.Property;
 import org.apache.logging.log4j.core.config.plugins.Plugin;
+import org.apache.logging.log4j.core.config.plugins.PluginAttribute;
+import org.apache.logging.log4j.core.config.plugins.PluginElement;
 import org.apache.logging.log4j.core.config.plugins.PluginFactory;
 
-import java.io.Serializable;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -22,14 +22,14 @@ public final class Trackers extends AbstractAppender {
 
     private final Set<Tracker> trackers;
 
-    private Trackers(String name, Filter filter, Layout<? extends Serializable> layout, boolean ignoreExceptions, Property[] properties) {
-        super(name, filter, layout, ignoreExceptions, properties);
+    private Trackers(String name, Filter filter) {
+        super(name, filter, null, true, Property.EMPTY_ARRAY);
         this.trackers = loadTrackers();
     }
 
     @PluginFactory
-    public static Trackers newInstance(String name, Filter filter, Layout<? extends Serializable> layout, boolean ignoreExceptions, Property[] properties) {
-        return new Trackers(name, filter, layout, ignoreExceptions, properties);
+    public static Trackers newInstance(@PluginAttribute("name") String name, @PluginElement("Filter") Filter filter) {
+        return new Trackers(name, filter);
     }
 
     @Override

--- a/qudini-reactive-logging/src/main/java/com/qudini/reactive/logging/log4j2/trackers/NewRelicTracker.java
+++ b/qudini-reactive-logging/src/main/java/com/qudini/reactive/logging/log4j2/trackers/NewRelicTracker.java
@@ -1,19 +1,19 @@
 package com.qudini.reactive.logging.log4j2.trackers;
 
 import com.newrelic.api.agent.NewRelic;
+import com.qudini.reactive.logging.log4j2.QudiniLogEvent;
 import com.qudini.reactive.logging.log4j2.Tracker;
-import org.apache.logging.log4j.core.LogEvent;
 
 import java.util.Optional;
 
 public final class NewRelicTracker implements Tracker {
 
     @Override
-    public void track(LogEvent event) {
-        event.getContextData().forEach((key, value) -> NewRelic.addCustomParameter(key, String.valueOf(value)));
-        Optional.ofNullable(event.getThrown()).ifPresentOrElse(
+    public void track(QudiniLogEvent event) {
+        event.getContext().forEach((key, value) -> NewRelic.addCustomParameter(key, String.valueOf(value)));
+        Optional.ofNullable(event.getError()).ifPresentOrElse(
                 NewRelic::noticeError,
-                () -> NewRelic.noticeError(event.getMessage().getFormattedMessage())
+                () -> NewRelic.noticeError(event.getMessage())
         );
     }
 

--- a/qudini-reactive-logging/src/main/java/com/qudini/reactive/logging/log4j2/trackers/NewRelicTracker.java
+++ b/qudini-reactive-logging/src/main/java/com/qudini/reactive/logging/log4j2/trackers/NewRelicTracker.java
@@ -4,14 +4,33 @@ import com.newrelic.api.agent.NewRelic;
 import com.qudini.reactive.logging.log4j2.QudiniLogEvent;
 import com.qudini.reactive.logging.log4j2.Tracker;
 
+import java.util.HashMap;
+import java.util.Map;
+
+import static java.time.format.DateTimeFormatter.ISO_INSTANT;
+
 public final class NewRelicTracker implements Tracker {
+
+    private static final String TIMESTAMP_KEY = "timestamp";
+    private static final String LEVEL_KEY = "level";
+    private static final String LOGGER_KEY = "logger";
+    private static final String MESSAGE_KEY = "message";
 
     @Override
     public void track(QudiniLogEvent event) {
         event.getError().ifPresentOrElse(
-                error -> NewRelic.noticeError(error, event.getContext()),
-                () -> NewRelic.noticeError(event.getMessage(), event.getContext())
+                error -> NewRelic.noticeError(error, toNewRelicParams(event)),
+                () -> NewRelic.noticeError(event.getMessage(), toNewRelicParams(event))
         );
+    }
+
+    private static Map<String, String> toNewRelicParams(QudiniLogEvent event) {
+        var params = new HashMap<>(event.getContext());
+        params.put(TIMESTAMP_KEY, ISO_INSTANT.format(event.getTimestamp()));
+        params.put(LEVEL_KEY, event.getLevel().name());
+        event.getLogger().ifPresent(logger -> params.put(LOGGER_KEY, logger));
+        params.put(MESSAGE_KEY, event.getMessage());
+        return params;
     }
 
 }

--- a/qudini-reactive-logging/src/main/java/com/qudini/reactive/logging/log4j2/trackers/NewRelicTracker.java
+++ b/qudini-reactive-logging/src/main/java/com/qudini/reactive/logging/log4j2/trackers/NewRelicTracker.java
@@ -1,0 +1,20 @@
+package com.qudini.reactive.logging.log4j2.trackers;
+
+import com.newrelic.api.agent.NewRelic;
+import com.qudini.reactive.logging.log4j2.Tracker;
+import org.apache.logging.log4j.core.LogEvent;
+
+import java.util.Optional;
+
+public final class NewRelicTracker implements Tracker {
+
+    @Override
+    public void track(LogEvent event) {
+        event.getContextData().forEach((key, value) -> NewRelic.addCustomParameter(key, String.valueOf(value)));
+        Optional.ofNullable(event.getThrown()).ifPresentOrElse(
+                NewRelic::noticeError,
+                () -> NewRelic.noticeError(event.getMessage().getFormattedMessage())
+        );
+    }
+
+}

--- a/qudini-reactive-logging/src/main/java/com/qudini/reactive/logging/log4j2/trackers/NewRelicTracker.java
+++ b/qudini-reactive-logging/src/main/java/com/qudini/reactive/logging/log4j2/trackers/NewRelicTracker.java
@@ -4,14 +4,12 @@ import com.newrelic.api.agent.NewRelic;
 import com.qudini.reactive.logging.log4j2.QudiniLogEvent;
 import com.qudini.reactive.logging.log4j2.Tracker;
 
-import java.util.Optional;
-
 public final class NewRelicTracker implements Tracker {
 
     @Override
     public void track(QudiniLogEvent event) {
         event.getContext().forEach((key, value) -> NewRelic.addCustomParameter(key, String.valueOf(value)));
-        Optional.ofNullable(event.getError()).ifPresentOrElse(
+        event.getError().ifPresentOrElse(
                 NewRelic::noticeError,
                 () -> NewRelic.noticeError(event.getMessage())
         );

--- a/qudini-reactive-logging/src/main/java/com/qudini/reactive/logging/log4j2/trackers/NewRelicTracker.java
+++ b/qudini-reactive-logging/src/main/java/com/qudini/reactive/logging/log4j2/trackers/NewRelicTracker.java
@@ -18,9 +18,10 @@ public final class NewRelicTracker implements Tracker {
 
     @Override
     public void track(QudiniLogEvent event) {
+        var params = toNewRelicParams(event);
         event.getError().ifPresentOrElse(
-                error -> NewRelic.noticeError(error, toNewRelicParams(event)),
-                () -> NewRelic.noticeError(event.getMessage(), toNewRelicParams(event))
+                error -> NewRelic.noticeError(error, params),
+                () -> NewRelic.noticeError(event.getMessage(), params)
         );
     }
 

--- a/qudini-reactive-logging/src/main/java/com/qudini/reactive/logging/log4j2/trackers/NewRelicTracker.java
+++ b/qudini-reactive-logging/src/main/java/com/qudini/reactive/logging/log4j2/trackers/NewRelicTracker.java
@@ -8,10 +8,9 @@ public final class NewRelicTracker implements Tracker {
 
     @Override
     public void track(QudiniLogEvent event) {
-        event.getContext().forEach((key, value) -> NewRelic.addCustomParameter(key, String.valueOf(value)));
         event.getError().ifPresentOrElse(
-                NewRelic::noticeError,
-                () -> NewRelic.noticeError(event.getMessage())
+                error -> NewRelic.noticeError(error, event.getContext()),
+                () -> NewRelic.noticeError(event.getMessage(), event.getContext())
         );
     }
 

--- a/qudini-reactive-logging/src/main/java/com/qudini/reactive/logging/log4j2/trackers/SentryTracker.java
+++ b/qudini-reactive-logging/src/main/java/com/qudini/reactive/logging/log4j2/trackers/SentryTracker.java
@@ -1,0 +1,20 @@
+package com.qudini.reactive.logging.log4j2.trackers;
+
+import com.qudini.reactive.logging.log4j2.Tracker;
+import io.sentry.Sentry;
+import org.apache.logging.log4j.core.LogEvent;
+
+import java.util.Optional;
+
+public final class SentryTracker implements Tracker {
+
+    @Override
+    public void track(LogEvent event) {
+        Sentry.configureScope(scope -> event.getContextData().forEach(scope::setContexts));
+        Optional.ofNullable(event.getThrown()).ifPresentOrElse(
+                Sentry::captureException,
+                () -> Sentry.captureMessage(event.getMessage().getFormattedMessage())
+        );
+    }
+
+}

--- a/qudini-reactive-logging/src/main/java/com/qudini/reactive/logging/log4j2/trackers/SentryTracker.java
+++ b/qudini-reactive-logging/src/main/java/com/qudini/reactive/logging/log4j2/trackers/SentryTracker.java
@@ -4,14 +4,12 @@ import com.qudini.reactive.logging.log4j2.QudiniLogEvent;
 import com.qudini.reactive.logging.log4j2.Tracker;
 import io.sentry.Sentry;
 
-import java.util.Optional;
-
 public final class SentryTracker implements Tracker {
 
     @Override
     public void track(QudiniLogEvent event) {
         Sentry.configureScope(scope -> event.getContext().forEach(scope::setContexts));
-        Optional.ofNullable(event.getError()).ifPresentOrElse(
+        event.getError().ifPresentOrElse(
                 Sentry::captureException,
                 () -> Sentry.captureMessage(event.getMessage())
         );

--- a/qudini-reactive-logging/src/main/java/com/qudini/reactive/logging/log4j2/trackers/SentryTracker.java
+++ b/qudini-reactive-logging/src/main/java/com/qudini/reactive/logging/log4j2/trackers/SentryTracker.java
@@ -14,6 +14,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static com.qudini.reactive.logging.web.DefaultLoggingContextExtractor.BUILD_VERSION_KEY;
+import static com.qudini.reactive.logging.web.DefaultLoggingContextExtractor.ENVIRONMENT_KEY;
 
 public final class SentryTracker implements Tracker {
 
@@ -27,10 +28,10 @@ public final class SentryTracker implements Tracker {
         sentryEvent.setMessage(toSentryMessage(logEvent.getMessage()));
         sentryEvent.setLevel(toSentryLevel(logEvent.getLevel()));
         Optional.ofNullable(logEvent.getContext().get(BUILD_VERSION_KEY)).ifPresent(sentryEvent::setRelease);
+        Optional.ofNullable(logEvent.getContext().get(ENVIRONMENT_KEY)).ifPresent(sentryEvent::setEnvironment);
         sentryEvent.setContexts(toSentryContexts(logEvent.getContext()));
         logEvent.getLogger().ifPresent(sentryEvent::setLogger);
         logEvent.getError().ifPresent(sentryEvent::setThrowable);
-//        sentryEvent.setEnvironment();
         return sentryEvent;
     }
 
@@ -58,6 +59,7 @@ public final class SentryTracker implements Tracker {
         var contexts = new Contexts();
         logContext.forEach(contexts::put);
         contexts.remove(BUILD_VERSION_KEY);
+        contexts.remove(ENVIRONMENT_KEY);
         return contexts;
     }
 

--- a/qudini-reactive-logging/src/main/java/com/qudini/reactive/logging/log4j2/trackers/SentryTracker.java
+++ b/qudini-reactive-logging/src/main/java/com/qudini/reactive/logging/log4j2/trackers/SentryTracker.java
@@ -3,16 +3,62 @@ package com.qudini.reactive.logging.log4j2.trackers;
 import com.qudini.reactive.logging.log4j2.QudiniLogEvent;
 import com.qudini.reactive.logging.log4j2.Tracker;
 import io.sentry.Sentry;
+import io.sentry.SentryEvent;
+import io.sentry.SentryLevel;
+import io.sentry.protocol.Contexts;
+import io.sentry.protocol.Message;
+import org.apache.logging.log4j.Level;
+
+import java.sql.Date;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.qudini.reactive.logging.web.DefaultLoggingContextExtractor.BUILD_VERSION_KEY;
 
 public final class SentryTracker implements Tracker {
 
     @Override
     public void track(QudiniLogEvent event) {
-        Sentry.configureScope(scope -> event.getContext().forEach(scope::setContexts));
-        event.getError().ifPresentOrElse(
-                Sentry::captureException,
-                () -> Sentry.captureMessage(event.getMessage())
-        );
+        Sentry.captureEvent(toSentryEvent(event));
+    }
+
+    private static SentryEvent toSentryEvent(QudiniLogEvent logEvent) {
+        var sentryEvent = new SentryEvent(Date.from(logEvent.getTimestamp()));
+        sentryEvent.setMessage(toSentryMessage(logEvent.getMessage()));
+        sentryEvent.setLevel(toSentryLevel(logEvent.getLevel()));
+        Optional.ofNullable(logEvent.getContext().get(BUILD_VERSION_KEY)).ifPresent(sentryEvent::setRelease);
+        sentryEvent.setContexts(toSentryContexts(logEvent.getContext()));
+        logEvent.getLogger().ifPresent(sentryEvent::setLogger);
+        logEvent.getError().ifPresent(sentryEvent::setThrowable);
+//        sentryEvent.setEnvironment();
+        return sentryEvent;
+    }
+
+    private static Message toSentryMessage(String logMessage) {
+        var message = new Message();
+        message.setFormatted(logMessage);
+        return message;
+    }
+
+    private static SentryLevel toSentryLevel(Level logLevel) {
+        if (logLevel.isMoreSpecificThan(Level.FATAL)) {
+            return SentryLevel.FATAL;
+        } else if (logLevel.isMoreSpecificThan(Level.ERROR)) {
+            return SentryLevel.ERROR;
+        } else if (logLevel.isMoreSpecificThan(Level.WARN)) {
+            return SentryLevel.WARNING;
+        } else if (logLevel.isMoreSpecificThan(Level.INFO)) {
+            return SentryLevel.INFO;
+        } else {
+            return SentryLevel.DEBUG;
+        }
+    }
+
+    private static Contexts toSentryContexts(Map<String, String> logContext) {
+        var contexts = new Contexts();
+        logContext.forEach(contexts::put);
+        contexts.remove(BUILD_VERSION_KEY);
+        return contexts;
     }
 
 }

--- a/qudini-reactive-logging/src/main/java/com/qudini/reactive/logging/log4j2/trackers/SentryTracker.java
+++ b/qudini-reactive-logging/src/main/java/com/qudini/reactive/logging/log4j2/trackers/SentryTracker.java
@@ -1,19 +1,19 @@
 package com.qudini.reactive.logging.log4j2.trackers;
 
+import com.qudini.reactive.logging.log4j2.QudiniLogEvent;
 import com.qudini.reactive.logging.log4j2.Tracker;
 import io.sentry.Sentry;
-import org.apache.logging.log4j.core.LogEvent;
 
 import java.util.Optional;
 
 public final class SentryTracker implements Tracker {
 
     @Override
-    public void track(LogEvent event) {
-        Sentry.configureScope(scope -> event.getContextData().forEach(scope::setContexts));
-        Optional.ofNullable(event.getThrown()).ifPresentOrElse(
+    public void track(QudiniLogEvent event) {
+        Sentry.configureScope(scope -> event.getContext().forEach(scope::setContexts));
+        Optional.ofNullable(event.getError()).ifPresentOrElse(
                 Sentry::captureException,
-                () -> Sentry.captureMessage(event.getMessage().getFormattedMessage())
+                () -> Sentry.captureMessage(event.getMessage())
         );
     }
 

--- a/qudini-reactive-logging/src/main/java/com/qudini/reactive/logging/log4j2/trackers/SentryTracker.java
+++ b/qudini-reactive-logging/src/main/java/com/qudini/reactive/logging/log4j2/trackers/SentryTracker.java
@@ -2,6 +2,7 @@ package com.qudini.reactive.logging.log4j2.trackers;
 
 import com.qudini.reactive.logging.log4j2.QudiniLogEvent;
 import com.qudini.reactive.logging.log4j2.Tracker;
+import com.qudini.reactive.utils.metadata.MetadataService;
 import io.sentry.Sentry;
 import io.sentry.SentryEvent;
 import io.sentry.SentryLevel;
@@ -17,6 +18,14 @@ import static com.qudini.reactive.logging.web.DefaultLoggingContextExtractor.BUI
 import static com.qudini.reactive.logging.web.DefaultLoggingContextExtractor.ENVIRONMENT_KEY;
 
 public final class SentryTracker implements Tracker {
+
+    @Override
+    public void init(MetadataService metadataService) {
+        Sentry.init(options -> {
+            options.setEnvironment(metadataService.getEnvironment());
+            options.setRelease(metadataService.getBuildVersion());
+        });
+    }
 
     @Override
     public void track(QudiniLogEvent event) {

--- a/qudini-reactive-logging/src/main/java/com/qudini/reactive/logging/web/DefaultLoggingContextExtractor.java
+++ b/qudini-reactive-logging/src/main/java/com/qudini/reactive/logging/web/DefaultLoggingContextExtractor.java
@@ -10,6 +10,7 @@ import java.util.Map;
 @RequiredArgsConstructor
 public final class DefaultLoggingContextExtractor implements LoggingContextExtractor {
 
+    public static final String BUILD_NAME_KEY = "build_name";
     public static final String BUILD_VERSION_KEY = "build_version";
 
     private final BuildInfoService buildInfoService;
@@ -17,6 +18,7 @@ public final class DefaultLoggingContextExtractor implements LoggingContextExtra
     @Override
     public Mono<Map<String, String>> extract(ServerWebExchange exchange) {
         return Mono.just(Map.of(
+                BUILD_NAME_KEY, buildInfoService.getName(),
                 BUILD_VERSION_KEY, buildInfoService.getVersion()
         ));
     }

--- a/qudini-reactive-logging/src/main/java/com/qudini/reactive/logging/web/DefaultLoggingContextExtractor.java
+++ b/qudini-reactive-logging/src/main/java/com/qudini/reactive/logging/web/DefaultLoggingContextExtractor.java
@@ -1,6 +1,6 @@
 package com.qudini.reactive.logging.web;
 
-import com.qudini.reactive.utils.build.BuildInfoService;
+import com.qudini.reactive.utils.metadata.MetadataService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
@@ -10,16 +10,18 @@ import java.util.Map;
 @RequiredArgsConstructor
 public final class DefaultLoggingContextExtractor implements LoggingContextExtractor {
 
+    public static final String ENVIRONMENT_KEY = "environment";
     public static final String BUILD_NAME_KEY = "build_name";
     public static final String BUILD_VERSION_KEY = "build_version";
 
-    private final BuildInfoService buildInfoService;
+    private final MetadataService metadataService;
 
     @Override
     public Mono<Map<String, String>> extract(ServerWebExchange exchange) {
         return Mono.just(Map.of(
-                BUILD_NAME_KEY, buildInfoService.getName(),
-                BUILD_VERSION_KEY, buildInfoService.getVersion()
+                ENVIRONMENT_KEY, metadataService.getEnvironment(),
+                BUILD_NAME_KEY, metadataService.getBuildName(),
+                BUILD_VERSION_KEY, metadataService.getBuildVersion()
         ));
     }
 

--- a/qudini-reactive-logging/src/main/java/com/qudini/reactive/logging/web/DefaultLoggingContextExtractor.java
+++ b/qudini-reactive-logging/src/main/java/com/qudini/reactive/logging/web/DefaultLoggingContextExtractor.java
@@ -1,15 +1,24 @@
 package com.qudini.reactive.logging.web;
 
+import com.qudini.reactive.utils.build.BuildInfoService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
 
 import java.util.Map;
 
+@RequiredArgsConstructor
 public final class DefaultLoggingContextExtractor implements LoggingContextExtractor {
+
+    public static final String BUILD_VERSION_KEY = "build_version";
+
+    private final BuildInfoService buildInfoService;
 
     @Override
     public Mono<Map<String, String>> extract(ServerWebExchange exchange) {
-        return Mono.just(Map.of());
+        return Mono.just(Map.of(
+                BUILD_VERSION_KEY, buildInfoService.getVersion()
+        ));
     }
 
 }

--- a/qudini-reactive-logging/src/main/java/com/qudini/reactive/logging/web/DefaultLoggingContextExtractor.java
+++ b/qudini-reactive-logging/src/main/java/com/qudini/reactive/logging/web/DefaultLoggingContextExtractor.java
@@ -10,19 +10,13 @@ import java.util.Map;
 @RequiredArgsConstructor
 public final class DefaultLoggingContextExtractor implements LoggingContextExtractor {
 
-    public static final String ENVIRONMENT_KEY = "environment";
-    public static final String BUILD_NAME_KEY = "build_name";
     public static final String BUILD_VERSION_KEY = "build_version";
 
     private final MetadataService metadataService;
 
     @Override
     public Mono<Map<String, String>> extract(ServerWebExchange exchange) {
-        return Mono.just(Map.of(
-                ENVIRONMENT_KEY, metadataService.getEnvironment(),
-                BUILD_NAME_KEY, metadataService.getBuildName(),
-                BUILD_VERSION_KEY, metadataService.getBuildVersion()
-        ));
+        return Mono.just(Map.of(BUILD_VERSION_KEY, metadataService.getBuildVersion()));
     }
 
 }

--- a/qudini-reactive-logging/src/main/resources/qudini-log4j2.xml
+++ b/qudini-reactive-logging/src/main/resources/qudini-log4j2.xml
@@ -4,10 +4,12 @@
         <Console name="Console" target="SYSTEM_OUT">
             <QudiniJsonLayout/>
         </Console>
+        <ErrorTrackerAppender name="ErrorTrackerAppender"/>
     </Appenders>
     <Loggers>
         <AsyncRoot level="${env:LOG_LEVEL:-INFO}">
             <AppenderRef ref="Console"/>
+            <AppenderRef ref="ErrorTrackerAppender"/>
         </AsyncRoot>
     </Loggers>
 </Configuration>

--- a/qudini-reactive-logging/src/main/resources/qudini-log4j2.xml
+++ b/qudini-reactive-logging/src/main/resources/qudini-log4j2.xml
@@ -4,12 +4,12 @@
         <Console name="Console" target="SYSTEM_OUT">
             <QudiniJsonLayout/>
         </Console>
-        <ErrorTrackerAppender name="ErrorTrackerAppender"/>
+        <Trackers name="Trackers"/>
     </Appenders>
     <Loggers>
         <AsyncRoot level="${env:LOG_LEVEL:-INFO}">
             <AppenderRef ref="Console"/>
-            <AppenderRef ref="ErrorTrackerAppender"/>
+            <AppenderRef ref="Trackers" level="error"/>
         </AsyncRoot>
     </Loggers>
 </Configuration>

--- a/qudini-reactive-logging/src/test/java/com/qudini/reactive/logging/web/DefaultLoggingContextExtractorTest.java
+++ b/qudini-reactive-logging/src/test/java/com/qudini/reactive/logging/web/DefaultLoggingContextExtractorTest.java
@@ -28,17 +28,11 @@ class DefaultLoggingContextExtractorTest {
     private DefaultLoggingContextExtractor extractor;
 
     @Test
-    @DisplayName("should return a map holding the metadata")
+    @DisplayName("should return a map holding the build version")
     void emptyMap() {
-        given(metadataService.getEnvironment()).willReturn("test env");
-        given(metadataService.getBuildName()).willReturn("build name");
         given(metadataService.getBuildVersion()).willReturn("build version");
         var context = extractor.extract(exchange).block();
-        assertThat(context).isEqualTo(Map.of(
-                "environment", "test env",
-                "build_name", "build name",
-                "build_version", "build version"
-        ));
+        assertThat(context).isEqualTo(Map.of("build_version", "build version"));
     }
 
 }

--- a/qudini-reactive-logging/src/test/java/com/qudini/reactive/logging/web/DefaultLoggingContextExtractorTest.java
+++ b/qudini-reactive-logging/src/test/java/com/qudini/reactive/logging/web/DefaultLoggingContextExtractorTest.java
@@ -1,5 +1,6 @@
 package com.qudini.reactive.logging.web;
 
+import com.qudini.reactive.utils.build.BuildInfoService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -8,7 +9,10 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.web.server.ServerWebExchange;
 
+import java.util.Map;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("DefaultLoggingContextExtractor")
@@ -17,14 +21,18 @@ class DefaultLoggingContextExtractorTest {
     @Mock
     private ServerWebExchange exchange;
 
+    @Mock
+    private BuildInfoService buildInfoService;
+
     @InjectMocks
     private DefaultLoggingContextExtractor extractor;
 
     @Test
-    @DisplayName("should return an empty map")
+    @DisplayName("should return a map holding the build version")
     void emptyMap() {
+        given(buildInfoService.getVersion()).willReturn("42");
         var context = extractor.extract(exchange).block();
-        assertThat(context).isEmpty();
+        assertThat(context).isEqualTo(Map.of("build_version", "42"));
     }
 
 }

--- a/qudini-reactive-logging/src/test/java/com/qudini/reactive/logging/web/DefaultLoggingContextExtractorTest.java
+++ b/qudini-reactive-logging/src/test/java/com/qudini/reactive/logging/web/DefaultLoggingContextExtractorTest.java
@@ -1,6 +1,6 @@
 package com.qudini.reactive.logging.web;
 
-import com.qudini.reactive.utils.build.BuildInfoService;
+import com.qudini.reactive.utils.metadata.MetadataService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -22,17 +22,23 @@ class DefaultLoggingContextExtractorTest {
     private ServerWebExchange exchange;
 
     @Mock
-    private BuildInfoService buildInfoService;
+    private MetadataService metadataService;
 
     @InjectMocks
     private DefaultLoggingContextExtractor extractor;
 
     @Test
-    @DisplayName("should return a map holding the build version")
+    @DisplayName("should return a map holding the metadata")
     void emptyMap() {
-        given(buildInfoService.getVersion()).willReturn("42");
+        given(metadataService.getEnvironment()).willReturn("test env");
+        given(metadataService.getBuildName()).willReturn("build name");
+        given(metadataService.getBuildVersion()).willReturn("build version");
         var context = extractor.extract(exchange).block();
-        assertThat(context).isEqualTo(Map.of("build_version", "42"));
+        assertThat(context).isEqualTo(Map.of(
+                "environment", "test env",
+                "build_name", "build name",
+                "build_version", "build version"
+        ));
     }
 
 }

--- a/qudini-reactive-metrics/README.md
+++ b/qudini-reactive-metrics/README.md
@@ -40,7 +40,7 @@ metrics:
     gauge-name-prefix: yourprefix
 ```
 
-These two values will be read from `com.qudini.reactive.utils.build.BuildInfoService`, [see the defaults and how to override them](https://github.com/qudini/qudini-reactive/tree/master/qudini-reactive-utils).
+These two values will be read from `com.qudini.reactive.utils.metadata.MetadataService` ([see the defaults and how to override them](https://github.com/qudini/qudini-reactive/tree/master/qudini-reactive-utils)).
 
 ### Probes
 

--- a/qudini-reactive-metrics/README.md
+++ b/qudini-reactive-metrics/README.md
@@ -6,6 +6,13 @@ Provides an easy integration of custom metrics, as well as health checks followi
 
 ```xml
 <dependencies>
+    <!-- Qudini Reactive dependencies needed: -->
+    <dependency>
+        <groupId>com.qudini</groupId>
+        <artifactId>qudini-reactive-utils</artifactId>
+        <version>${qudini-reactive.version}</version>
+    </dependency>
+    <!-- Main dependency: -->
     <dependency>
         <groupId>com.qudini</groupId>
         <artifactId>qudini-reactive-metrics</artifactId>
@@ -25,7 +32,7 @@ You can leave the defaults, everything will just work out of the box. You can al
 
 ### Build info
 
-A `Gauge` meter named `${prefix}_build_info` will be registered to expose the build name and version via tags. You can specify gauge name prefix:
+A `Gauge` meter named `${prefix}_build_info` will be registered to expose the build name and version via tags. You can specify gauge name prefix, defaulted to `app`:
 
 ```yaml
 metrics:
@@ -33,9 +40,7 @@ metrics:
     gauge-name-prefix: yourprefix
 ```
 
-By default, those two values will be read from the JAR file's manifest, respectively `Implementation-Title` and `Implementation-Version`.
-
-You can override this behaviour by registering a component implementing `com.qudini.reactive.metrics.buildinfo.BuildInfoService`.
+These two values will be read from `com.qudini.reactive.utils.build.BuildInfoService`, [see the defaults and how to override them if needed](https://github.com/qudini/qudini-reactive/tree/master/qudini-reactive-utils).
 
 ### Probes
 

--- a/qudini-reactive-metrics/README.md
+++ b/qudini-reactive-metrics/README.md
@@ -40,7 +40,7 @@ metrics:
     gauge-name-prefix: yourprefix
 ```
 
-These two values will be read from `com.qudini.reactive.utils.build.BuildInfoService`, [see the defaults and how to override them if needed](https://github.com/qudini/qudini-reactive/tree/master/qudini-reactive-utils).
+These two values will be read from `com.qudini.reactive.utils.build.BuildInfoService`, [see the defaults and how to override them](https://github.com/qudini/qudini-reactive/tree/master/qudini-reactive-utils).
 
 ### Probes
 

--- a/qudini-reactive-metrics/pom.xml
+++ b/qudini-reactive-metrics/pom.xml
@@ -16,6 +16,12 @@
     <dependencies>
         <dependency>
             <groupId>com.qudini</groupId>
+            <artifactId>qudini-reactive-utils</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.qudini</groupId>
             <artifactId>qudini-reactive-tests</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>

--- a/qudini-reactive-metrics/src/main/java/com/qudini/reactive/metrics/ReactiveMetricsAutoConfiguration.java
+++ b/qudini-reactive-metrics/src/main/java/com/qudini/reactive/metrics/ReactiveMetricsAutoConfiguration.java
@@ -1,13 +1,10 @@
 package com.qudini.reactive.metrics;
 
 import com.qudini.reactive.metrics.aop.MeasuredAspect;
-import com.qudini.reactive.metrics.buildinfo.BuildInfoMeterBinder;
-import com.qudini.reactive.metrics.buildinfo.BuildInfoService;
-import com.qudini.reactive.metrics.buildinfo.DefaultBuildInfoService;
+import com.qudini.reactive.metrics.build.BuildInfoMeterBinder;
+import com.qudini.reactive.utils.build.BuildInfoService;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.reactive.function.server.RouterFunction;
@@ -23,12 +20,6 @@ import static org.springframework.web.reactive.function.server.ServerResponse.ok
 
 @Configuration
 public class ReactiveMetricsAutoConfiguration {
-
-    @Bean
-    @ConditionalOnMissingBean
-    public BuildInfoService buildInfoService(ApplicationContext applicationContext) {
-        return new DefaultBuildInfoService(applicationContext);
-    }
 
     @Bean
     public BuildInfoMeterBinder buildInfoMeterBinder(

--- a/qudini-reactive-metrics/src/main/java/com/qudini/reactive/metrics/ReactiveMetricsAutoConfiguration.java
+++ b/qudini-reactive-metrics/src/main/java/com/qudini/reactive/metrics/ReactiveMetricsAutoConfiguration.java
@@ -2,7 +2,7 @@ package com.qudini.reactive.metrics;
 
 import com.qudini.reactive.metrics.aop.MeasuredAspect;
 import com.qudini.reactive.metrics.build.BuildInfoMeterBinder;
-import com.qudini.reactive.utils.build.BuildInfoService;
+import com.qudini.reactive.utils.metadata.MetadataService;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -23,10 +23,10 @@ public class ReactiveMetricsAutoConfiguration {
 
     @Bean
     public BuildInfoMeterBinder buildInfoMeterBinder(
-            BuildInfoService buildInfoService,
+            MetadataService metadataService,
             @Value("${metrics.build-info.gauge-name-prefix:app}") String gaugeNamePrefix
     ) {
-        return new BuildInfoMeterBinder(buildInfoService, gaugeNamePrefix);
+        return new BuildInfoMeterBinder(metadataService, gaugeNamePrefix);
     }
 
     @Bean

--- a/qudini-reactive-metrics/src/main/java/com/qudini/reactive/metrics/build/BuildInfoMeterBinder.java
+++ b/qudini-reactive-metrics/src/main/java/com/qudini/reactive/metrics/build/BuildInfoMeterBinder.java
@@ -1,5 +1,6 @@
-package com.qudini.reactive.metrics.buildinfo;
+package com.qudini.reactive.metrics.build;
 
+import com.qudini.reactive.utils.build.BuildInfoService;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.binder.MeterBinder;

--- a/qudini-reactive-metrics/src/main/java/com/qudini/reactive/metrics/build/BuildInfoMeterBinder.java
+++ b/qudini-reactive-metrics/src/main/java/com/qudini/reactive/metrics/build/BuildInfoMeterBinder.java
@@ -1,6 +1,6 @@
 package com.qudini.reactive.metrics.build;
 
-import com.qudini.reactive.utils.build.BuildInfoService;
+import com.qudini.reactive.utils.metadata.MetadataService;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.binder.MeterBinder;
@@ -9,7 +9,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public final class BuildInfoMeterBinder implements MeterBinder {
 
-    private final BuildInfoService buildInfoService;
+    private final MetadataService metadataService;
 
     private final String gaugeNamePrefix;
 
@@ -17,8 +17,8 @@ public final class BuildInfoMeterBinder implements MeterBinder {
     public void bindTo(MeterRegistry registry) {
         Gauge
                 .builder(gaugeNamePrefix + "_build_info", () -> 1)
-                .tag("name", buildInfoService.getName())
-                .tag("version", buildInfoService.getVersion())
+                .tag("name", metadataService.getBuildName())
+                .tag("version", metadataService.getBuildVersion())
                 .register(registry);
     }
 

--- a/qudini-reactive-sqs/src/main/java/com/qudini/reactive/sqs/ReactiveSqsAutoConfiguration.java
+++ b/qudini-reactive-sqs/src/main/java/com/qudini/reactive/sqs/ReactiveSqsAutoConfiguration.java
@@ -46,7 +46,7 @@ public class ReactiveSqsAutoConfiguration {
     public void start(ApplicationReadyEvent applicationReadyEvent) {
         applicationReadyEvent
                 .getApplicationContext()
-                .getBean("sqsListeners", SqsListeners.class)
+                .getBean(SqsListeners.class)
                 .start();
     }
 

--- a/qudini-reactive-utils/README.md
+++ b/qudini-reactive-utils/README.md
@@ -14,6 +14,18 @@ Utilities around Project Reactor.
 </dependencies>
 ```
 
+## Configuration
+
+You can leave the defaults, everything will just work out of the box. You can also reconfigure it to match your requirements, as explained in the following sections.
+
+### Build info
+
+`com.qudini.reactive.utils.build.BuildInfoService` will expose the build name and version.
+
+By default, those two values will be read from the JAR file's manifest, respectively `Implementation-Title` and `Implementation-Version`.
+
+You can override this behaviour by registering a component implementing `com.qudini.reactive.utils.build.BuildInfoService`.
+
 ## Usage
 
 ### com.qudini.reactive.utils.MoreMonos

--- a/qudini-reactive-utils/README.md
+++ b/qudini-reactive-utils/README.md
@@ -18,13 +18,15 @@ Utilities around Project Reactor.
 
 You can leave the defaults, everything will just work out of the box. You can also reconfigure it to match your requirements, as explained in the following sections.
 
-### Build info
+### Metadata
 
-`com.qudini.reactive.utils.build.BuildInfoService` will expose the build name and version.
+You can inject `com.qudini.reactive.utils.metadata.MetadataService` to access metadata about the artifact and the environment. By default:
 
-By default, those two values will be read from the JAR file's manifest, respectively `Implementation-Title` and `Implementation-Version`.
+- the environment will be read from the environment variable `K8S_NAMESPACE`,
+- the build name will be read from the JAR file's manifest `Implementation-Title`,
+- the build version will be read from the JAR file's manifest `Implementation-Version`.
 
-You can override this behaviour by registering a component implementing `com.qudini.reactive.utils.build.BuildInfoService`.
+You can override this behaviour by registering a component implementing `com.qudini.reactive.utils.metadata.MetadataService`.
 
 ## Usage
 

--- a/qudini-reactive-utils/src/main/java/com/qudini/reactive/utils/ReactiveUtilsAutoConfiguration.java
+++ b/qudini-reactive-utils/src/main/java/com/qudini/reactive/utils/ReactiveUtilsAutoConfiguration.java
@@ -1,0 +1,19 @@
+package com.qudini.reactive.utils;
+
+import com.qudini.reactive.utils.build.BuildInfoService;
+import com.qudini.reactive.utils.build.DefaultBuildInfoService;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ReactiveUtilsAutoConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean
+    public BuildInfoService buildInfoService(ApplicationContext applicationContext) {
+        return new DefaultBuildInfoService(applicationContext);
+    }
+
+}

--- a/qudini-reactive-utils/src/main/java/com/qudini/reactive/utils/ReactiveUtilsAutoConfiguration.java
+++ b/qudini-reactive-utils/src/main/java/com/qudini/reactive/utils/ReactiveUtilsAutoConfiguration.java
@@ -14,8 +14,8 @@ public class ReactiveUtilsAutoConfiguration {
     @Bean
     @ConditionalOnMissingBean
     public MetadataService buildMetadataService(
-            ApplicationContext applicationContext,
-            @Value("${K8S_NAMESPACE}") String environment
+            @Value("${K8S_NAMESPACE}") String environment,
+            ApplicationContext applicationContext
     ) {
         return new DefaultMetadataService(environment, applicationContext);
     }

--- a/qudini-reactive-utils/src/main/java/com/qudini/reactive/utils/ReactiveUtilsAutoConfiguration.java
+++ b/qudini-reactive-utils/src/main/java/com/qudini/reactive/utils/ReactiveUtilsAutoConfiguration.java
@@ -1,7 +1,8 @@
 package com.qudini.reactive.utils;
 
-import com.qudini.reactive.utils.build.BuildInfoService;
-import com.qudini.reactive.utils.build.DefaultBuildInfoService;
+import com.qudini.reactive.utils.metadata.MetadataService;
+import com.qudini.reactive.utils.metadata.DefaultMetadataService;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
@@ -12,8 +13,11 @@ public class ReactiveUtilsAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    public BuildInfoService buildInfoService(ApplicationContext applicationContext) {
-        return new DefaultBuildInfoService(applicationContext);
+    public MetadataService buildMetadataService(
+            ApplicationContext applicationContext,
+            @Value("${K8S_NAMESPACE}") String environment
+    ) {
+        return new DefaultMetadataService(environment, applicationContext);
     }
 
 }

--- a/qudini-reactive-utils/src/main/java/com/qudini/reactive/utils/build/BuildInfoService.java
+++ b/qudini-reactive-utils/src/main/java/com/qudini/reactive/utils/build/BuildInfoService.java
@@ -1,4 +1,4 @@
-package com.qudini.reactive.metrics.buildinfo;
+package com.qudini.reactive.utils.build;
 
 public interface BuildInfoService {
 

--- a/qudini-reactive-utils/src/main/java/com/qudini/reactive/utils/build/BuildInfoService.java
+++ b/qudini-reactive-utils/src/main/java/com/qudini/reactive/utils/build/BuildInfoService.java
@@ -1,9 +1,0 @@
-package com.qudini.reactive.utils.build;
-
-public interface BuildInfoService {
-
-    String getName();
-
-    String getVersion();
-
-}

--- a/qudini-reactive-utils/src/main/java/com/qudini/reactive/utils/build/DefaultBuildInfoService.java
+++ b/qudini-reactive-utils/src/main/java/com/qudini/reactive/utils/build/DefaultBuildInfoService.java
@@ -1,4 +1,4 @@
-package com.qudini.reactive.metrics.buildinfo;
+package com.qudini.reactive.utils.build;
 
 import lombok.Getter;
 import org.springframework.boot.autoconfigure.SpringBootApplication;

--- a/qudini-reactive-utils/src/main/java/com/qudini/reactive/utils/metadata/DefaultMetadataService.java
+++ b/qudini-reactive-utils/src/main/java/com/qudini/reactive/utils/metadata/DefaultMetadataService.java
@@ -1,21 +1,24 @@
-package com.qudini.reactive.utils.build;
+package com.qudini.reactive.utils.metadata;
 
 import lombok.Getter;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.ApplicationContext;
 
 @Getter
-public final class DefaultBuildInfoService implements BuildInfoService {
+public final class DefaultMetadataService implements MetadataService {
 
     private static final String DEFAULT_NAME = "unknown";
 
     private static final String DEFAULT_VERSION = "unknown";
 
-    private final String name;
+    private final String environment;
 
-    private final String version;
+    private final String buildName;
 
-    public DefaultBuildInfoService(ApplicationContext applicationContext) {
+    private final String buildVersion;
+
+    public DefaultMetadataService(String environment, ApplicationContext applicationContext) {
+        this.environment = environment;
         var applicationPackage = applicationContext
                 .getBeansWithAnnotation(SpringBootApplication.class)
                 .values()
@@ -23,10 +26,10 @@ public final class DefaultBuildInfoService implements BuildInfoService {
                 .findFirst()
                 .map(Object::getClass)
                 .map(Class::getPackage);
-        this.name = applicationPackage
+        this.buildName = applicationPackage
                 .map(Package::getImplementationTitle)
                 .orElse(DEFAULT_NAME);
-        this.version = applicationPackage
+        this.buildVersion = applicationPackage
                 .map(Package::getImplementationVersion)
                 .orElse(DEFAULT_VERSION);
     }

--- a/qudini-reactive-utils/src/main/java/com/qudini/reactive/utils/metadata/MetadataService.java
+++ b/qudini-reactive-utils/src/main/java/com/qudini/reactive/utils/metadata/MetadataService.java
@@ -1,0 +1,11 @@
+package com.qudini.reactive.utils.metadata;
+
+public interface MetadataService {
+
+    String getEnvironment();
+
+    String getBuildName();
+
+    String getBuildVersion();
+
+}

--- a/qudini-reactive-utils/src/main/resources/spring.factories
+++ b/qudini-reactive-utils/src/main/resources/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+com.qudini.reactive.utils.ReactiveUtilsAutoConfiguration


### PR DESCRIPTION
Adds a custom log4j2 appender, so that `ERROR` log events can be sent over to third-party services. Currently handling Sentry and NewRelic. This allows us to setting decent defaults to the various third-party properties.

A third-party service will only be taken into account if its JDK is in the classpath.

This PR also moves `BuildInfoService` from `metrics` over to `utils`, so that it is accessible from `logging` too, and renames it for `MetadataService` so that it can also hold the environment (defaulted to `K8S_NAMESPACE`), which then allows prepopulating the MDC with those metadata and passing them to the third-party services (should help to filter issues on their dashboards).

