### PR TITLE
Spring Boot 2.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.4.5</version>
+        <version>2.5.0</version>
     </parent>
 
     <licenses>

--- a/qudini-reactive-example/pom.xml
+++ b/qudini-reactive-example/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.4.5</version>
+        <version>2.5.0</version>
         <relativePath/>
     </parent>
 


### PR DESCRIPTION
https://spring.io/blog/2021/05/20/spring-boot-2-5-is-now-ga