### PR TITLE
Adding io.projectreactor:reactor-tools

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -250,6 +250,10 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-tools</artifactId>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
Adds [Reactor Debug Agent](https://projectreactor.io/docs/core/release/reference/#reactor-tools-debug), [automatically initialised by Spring Boot](https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/reactor/DebugAgentEnvironmentPostProcessor.html) if found in the classpath.