### PR TITLE
Spring Boot 2.6.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -314,6 +314,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <optional>true</optional>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.3</version>
+        <version>2.6.4</version>
     </parent>
 
     <properties>
@@ -25,14 +25,14 @@
         <skip-coverage>false</skip-coverage>
         <!-- Qudini-managed versions: -->
         <jsr305.version>3.0.2</jsr305.version>
-        <guava.version>31.0.1-jre</guava.version>
+        <guava.version>31.1-jre</guava.version>
         <testcontainers.version>1.16.3</testcontainers.version>
         <wiremock.version>2.32.0</wiremock.version>
         <lmax-disruptor.version>3.4.4</lmax-disruptor.version>
         <newrelic.version>7.5.0</newrelic.version>
         <newrelic-agent.sha256-checksum>14ebab1946a78f54ada6adda7559e6388919323cfefde29bc7b1c2a0e27709dc</newrelic-agent.sha256-checksum>
-        <sentry.version>5.6.1</sentry.version>
-        <aws-sdk.version>2.17.131</aws-sdk.version>
+        <sentry.version>5.6.2</sentry.version>
+        <aws-sdk.version>2.17.145</aws-sdk.version>
         <qudini-gom.version>7.3.3</qudini-gom.version>
         <lombok-plugin.version>1.18.20.0</lombok-plugin.version>
         <jacoco-plugin.version>0.8.7</jacoco-plugin.version>


### PR DESCRIPTION
Updating dependencies, notably:

- https://github.com/spring-projects/spring-boot/releases/tag/v2.6.4
- https://github.com/google/guava/releases/tag/v31.1
- https://github.com/getsentry/sentry-java/releases/tag/5.6.2