### PR TITLE
Renaming some methods in MoreCollectors 

### DIFF
--- a/qudini-reactive-utils/src/main/java/com/qudini/reactive/utils/MoreCollectors.java
+++ b/qudini-reactive-utils/src/main/java/com/qudini/reactive/utils/MoreCollectors.java
@@ -31,7 +31,7 @@ public final class MoreCollectors {
     /**
      * <p>Collects into a {@link Map}, mapping values with {@link Function#identity()}</p>
      */
-    public static <T, K> Collector<T, ?, Map<K, T>> toMap(
+    public static <T, K> Collector<T, ?, Map<K, T>> toIdentityMap(
             Function<? super T, ? extends K> keyMapper
     ) {
         return Collectors.toMap(keyMapper, identity());
@@ -40,7 +40,7 @@ public final class MoreCollectors {
     /**
      * <p>Collects into an unmodifiable {@link Map}, mapping values with {@link Function#identity()}</p>
      */
-    public static <T, K> Collector<T, ?, Map<K, T>> toUnmodifiableMap(
+    public static <T, K> Collector<T, ?, Map<K, T>> toUnmodifiableIdentityMap(
             Function<? super T, ? extends K> keyMapper
     ) {
         return Collectors.toUnmodifiableMap(keyMapper, identity());
@@ -49,7 +49,7 @@ public final class MoreCollectors {
     /**
      * <p>Collects into a {@link LinkedHashMap}, mapping values with {@link Function#identity()}</p>
      */
-    public static <T, K> Collector<T, ?, Map<K, T>> toLinkedMap(
+    public static <T, K> Collector<T, ?, Map<K, T>> toIdentityLinkedMap(
             Function<? super T, ? extends K> keyMapper
     ) {
         return toLinkedMap(keyMapper, identity());
@@ -73,7 +73,7 @@ public final class MoreCollectors {
     /**
      * <p>Collects into an unmodifiable {@link LinkedHashMap}, mapping values with {@link Function#identity()}</p>
      */
-    public static <T, K> Collector<T, ?, Map<K, T>> toUnmodifiableLinkedMap(
+    public static <T, K> Collector<T, ?, Map<K, T>> toUnmodifiableIdentityLinkedMap(
             Function<? super T, ? extends K> keyMapper
     ) {
         return toUnmodifiableLinkedMap(keyMapper, identity());
@@ -95,7 +95,7 @@ public final class MoreCollectors {
     /**
      * <p>Collects into a {@link TreeMap}, mapping values with {@link Function#identity()}</p>
      */
-    public static <T, K> Collector<T, ?, Map<K, T>> toTreeMap(
+    public static <T, K> Collector<T, ?, Map<K, T>> toIdentityTreeMap(
             Function<? super T, ? extends K> keyMapper
     ) {
         return toTreeMap(keyMapper, identity());
@@ -119,7 +119,7 @@ public final class MoreCollectors {
     /**
      * <p>Collects into an unmodifiable {@link TreeMap}, mapping values with {@link Function#identity()}</p>
      */
-    public static <T, K> Collector<T, ?, Map<K, T>> toUnmodifiableTreeMap(
+    public static <T, K> Collector<T, ?, Map<K, T>> toUnmodifiableIdentityTreeMap(
             Function<? super T, ? extends K> keyMapper
     ) {
         return toUnmodifiableTreeMap(keyMapper, identity());

--- a/qudini-reactive-utils/src/test/java/com/qudini/reactive/utils/MoreCollectorsTest.java
+++ b/qudini-reactive-utils/src/test/java/com/qudini/reactive/utils/MoreCollectorsTest.java
@@ -11,14 +11,18 @@ import java.util.stream.Stream;
 
 import static com.qudini.reactive.utils.MoreCollectors.groupingByUnmodifiable;
 import static com.qudini.reactive.utils.MoreCollectors.partitioningByUnmodifiable;
+import static com.qudini.reactive.utils.MoreCollectors.toIdentityLinkedMap;
+import static com.qudini.reactive.utils.MoreCollectors.toIdentityTreeMap;
 import static com.qudini.reactive.utils.MoreCollectors.toLinkedMap;
 import static com.qudini.reactive.utils.MoreCollectors.toLinkedSet;
-import static com.qudini.reactive.utils.MoreCollectors.toMap;
+import static com.qudini.reactive.utils.MoreCollectors.toIdentityMap;
 import static com.qudini.reactive.utils.MoreCollectors.toTreeMap;
 import static com.qudini.reactive.utils.MoreCollectors.toTreeSet;
+import static com.qudini.reactive.utils.MoreCollectors.toUnmodifiableIdentityLinkedMap;
+import static com.qudini.reactive.utils.MoreCollectors.toUnmodifiableIdentityTreeMap;
 import static com.qudini.reactive.utils.MoreCollectors.toUnmodifiableLinkedMap;
 import static com.qudini.reactive.utils.MoreCollectors.toUnmodifiableLinkedSet;
-import static com.qudini.reactive.utils.MoreCollectors.toUnmodifiableMap;
+import static com.qudini.reactive.utils.MoreCollectors.toUnmodifiableIdentityMap;
 import static com.qudini.reactive.utils.MoreCollectors.toUnmodifiableTreeMap;
 import static com.qudini.reactive.utils.MoreCollectors.toUnmodifiableTreeSet;
 import static java.util.Map.entry;
@@ -34,7 +38,7 @@ class MoreCollectorsTest {
     void mapIdentityValues() {
         var map = Stream
                 .of("aaa", "c", "bb")
-                .collect(toMap(String::length));
+                .collect(toIdentityMap(String::length));
         assertThat(map).containsExactlyInAnyOrderEntriesOf(Map.of(
                 3, "aaa",
                 1, "c",
@@ -48,7 +52,7 @@ class MoreCollectorsTest {
     void unmodifiableMapIdentityValues() {
         var map = Stream
                 .of("aaa", "c", "bb")
-                .collect(toUnmodifiableMap(String::length));
+                .collect(toUnmodifiableIdentityMap(String::length));
         assertThat(map).containsExactlyInAnyOrderEntriesOf(Map.of(
                 3, "aaa",
                 1, "c",
@@ -62,7 +66,7 @@ class MoreCollectorsTest {
     void linkedMapIdentityValues() {
         var map = Stream
                 .of("aaa", "c", "bb")
-                .collect(toLinkedMap(String::length));
+                .collect(toIdentityLinkedMap(String::length));
         assertThat(map).containsExactly(
                 entry(3, "aaa"),
                 entry(1, "c"),
@@ -90,7 +94,7 @@ class MoreCollectorsTest {
     void unmodifiableLinkedMapIdentityValues() {
         var map = Stream
                 .of("aaa", "c", "bb")
-                .collect(toUnmodifiableLinkedMap(String::length));
+                .collect(toUnmodifiableIdentityLinkedMap(String::length));
         assertThat(map).containsExactly(
                 entry(3, "aaa"),
                 entry(1, "c"),
@@ -118,7 +122,7 @@ class MoreCollectorsTest {
     void treeMapIdentityValues() {
         var map = Stream
                 .of("aaa", "c", "bb")
-                .collect(toTreeMap(String::length));
+                .collect(toIdentityTreeMap(String::length));
         assertThat(map).containsExactly(
                 entry(1, "c"),
                 entry(2, "bb"),
@@ -146,7 +150,7 @@ class MoreCollectorsTest {
     void unmodifiableTreeMapIdentityValues() {
         var map = Stream
                 .of("aaa", "c", "bb")
-                .collect(toUnmodifiableTreeMap(String::length));
+                .collect(toUnmodifiableIdentityTreeMap(String::length));
         assertThat(map).containsExactly(
                 entry(1, "c"),
                 entry(2, "bb"),


### PR DESCRIPTION
To avoid name clashes in static imports when `java.util.stream.Collectors` is used too