### PR TITLE
Update wiremock to standalone version. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -227,8 +227,8 @@
                 <version>${testcontainers.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.github.tomakehurst</groupId>
-                <artifactId>wiremock</artifactId>
+                <groupId>org.wiremock</groupId>
+                <artifactId>wiremock-standalone</artifactId>
                 <version>${wiremock.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
netty dependency is different from one in Spring Boot 3.2.2